### PR TITLE
Avoid setting output with deprecated method

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,4 +10,4 @@ git config --global user.name $2
 
 out=$(bumpver update $3)
 echo "$out"
-echo "::set-output name=out::$out"
+echo "name=$out" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Update according to https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/